### PR TITLE
Fix concatenate error for send_bat_email

### DIFF
--- a/V2.0/mailin.py
+++ b/V2.0/mailin.py
@@ -61,7 +61,7 @@ class Mailin:
   def campaign_recipients_export(self,id,notify_url,type):
     return self.post("campaign/" + id + "/recipients",json.dumps({"notify_url":notify_url,"type":type}))
   def send_bat_email(self,campid,email_to):
-    return self.post("campaign/" + campid + "/test",json.dumps({"emails":email_to}))
+    return self.post("campaign/" + str(campid) + "/test",json.dumps({"emails":email_to}))
   def create_trigger_campaign(self,category,from_name,name,bat_sent,html_content,html_url,listid,scheduled_date,subject,from_email,reply_to,to_field,exclude_list,recurring):
     return self.post("campaign",json.dumps({"category":category,"from_name":from_name,"trigger_name":name,"bat":bat_sent,"html_content":html_content,"html_url":html_url,"listid":listid,"scheduled_date":scheduled_date,"subject":subject,"from_email":from_email,"reply_to":reply_to,"to_field":to_field,"exclude_list":exclude_list,"recurring":recurring}))
   def update_trigger_campaign(self,id,category,from_name,name,bat_sent,html_content,html_url,listid,scheduled_date,subject,from_email,reply_to,to_field,exclude_list,recurring):


### PR DESCRIPTION
Fix concatenation of str + id by parsing it with str() function.

Error raised below:
  File "mail.py", line 6, in <module>
    result = m.send_bat_email(campid,email_to)
  File "mailin.py", line 64, in send_bat_email
    return self.post("campaign/" + campid + "/test",json.dumps({"emails":email_to}))
TypeError: cannot concatenate 'str' and 'int' objects